### PR TITLE
Speedup Travis by using PostgreSQL 9.5 from addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ addons:
 services:
   - postgresql
 before_script:
-  - bundle exec rake --trace db:create db:schema:load db:seed
+  - bundle exec rake --trace db:setup
 script:
-  - bundle exec rake spec
+  - bundle exec rspec --format progress --tag ~type:acceptance
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 ## postgres 9.5 setup adapted from: https://github.com/travis-ci/travis-ci/issues/4264
 
-sudo: required
+sudo: false
 dist: trusty
-services:
-  - postgresql
 addons:
   postgresql: "9.5"
+services:
+  - postgresql
 before_script:
   - bundle exec rake --trace db:create db:schema:load db:seed
 script:

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require File.expand_path('../config/application', __FILE__)
 
 ## override the output formatter setting in .rspec
 task :spec do
-  ENV['SPEC_OPTS'] = '--format progress'
+  ENV['SPEC_OPTS'] ||= '--format progress'
 end
 
 Rails.application.load_tasks

--- a/spec/app/domain/acceptance/response_bundling/integration_spec.rb
+++ b/spec/app/domain/acceptance/response_bundling/integration_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Response bundling" do
+RSpec.describe "Response bundling", type: :acceptance do
   let!(:avoid_autoload_errors) {
     Response.count;
     Services::RecordResponses::Service.new


### PR DESCRIPTION
Travis in container mode seems to sometimes run slower than expected, which is why I made the acceptance tests no longer run on Travis.

`rspec-rails` docs say there's a standard way to override its spec task, but it doesn't work...