### PR TITLE
why not return just update to 100, even if after gap

### DIFF
--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -19,11 +19,11 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
         ce.where(
           ce[:course_uuid].eq(course_uuid)
             .and(ce[:sequence_number].gteq(sequence_number_offset))
+            .and(ce[:sequence_number].lt(sequence_number_offset + limit))
             .and(ce[:type].in(request.fetch(:event_types)))
         )
         .order(:sequence_number)
         .project(ce[Arel.star], "'#{request_uuid}' AS \"request_uuid\"")
-        .take(limit)
       end
     )
 

--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -55,8 +55,6 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
       event_hashes = course_events.map do |event|
         is_gap = true if event.is_after_gap
 
-        next if is_gap
-
         {
           sequence_number: event.sequence_number,
           event_uuid: event.uuid,


### PR DESCRIPTION
this [next](https://github.com/openstax/biglearn-api/pull/48/files#diff-a05d0ddd23b0385e9aa82a72e4a691e3L58) assumes this pattern relative to the `sequence_number_offset` and `limit`:

`[event, event, event, gap, gap, gap]` where `limit` is > 6

however, in the case of:

`[event, event, event, gap, gap, event, event, event...]`, only the first 3 events will be returned, well short of the 6th event from the starting offset, or a limit of 6 events.

even worse, in the case of:

`[gap, gap, event, event, event...]`, no events are returned.  In fact, if we happen upon a gap, the only way to grab the events following is to increment `sequence_number_offset` by 1 until we happening upon the next event.  this is especially problematic with larger gaps.  however, if this is indeed the intent and other services are relying on this behavior...then i guess nvm about this.  if this neeeds to be the case, then can this return a `next_sequence_offset` or something similar?

if the intent if `limit` is to `limit` the number of events returned, then 1914a46 alone will fix the current problem.  however, if the intent is for `limit` to restrict sequence number to `sequence_number_offset` + `limit`, then 6079276 is needed as well.

needs specs and spec updates, but i wanted to ask about the intended behavior first, especially since current specs seem designed for cutting anything after a gap is encountered, even when it is a leading gap.



actually, :( the other thing that is happening is the first event after a gap does not get returned from the API at all.  For example, `160` will be in the qa biglearn api table, but the API returns blank until `sequence_number_offset` is `161`.  In courses with gaps in events, the number of events missing from the api is equal to the number of gaps - 1.