### PR TITLE
Added no-op events

### DIFF
--- a/app/models/course_event.rb
+++ b/app/models/course_event.rb
@@ -4,15 +4,16 @@ class CourseEvent < ApplicationRecord
   include AppendOnlyWithUniqueUuid
 
   enum type: {
-    create_course:                      0,
-    prepare_course_ecosystem:           1,
-    update_course_ecosystem:            2,
-    update_roster:                      3,
-    update_course_active_dates:         4,
-    update_globally_excluded_exercises: 5,
-    update_course_excluded_exercises:   6,
-    create_update_assignment:           7,
-    record_response:                    8
+    no_op:                              -1,
+    create_course:                       0,
+    prepare_course_ecosystem:            1,
+    update_course_ecosystem:             2,
+    update_roster:                       3,
+    update_course_active_dates:          4,
+    update_globally_excluded_exercises:  5,
+    update_course_excluded_exercises:    6,
+    create_update_assignment:            7,
+    record_response:                     8
   }
 
   validates :type,            presence: true

--- a/app/models/ecosystem_event.rb
+++ b/app/models/ecosystem_event.rb
@@ -4,7 +4,8 @@ class EcosystemEvent < ApplicationRecord
   include AppendOnlyWithUniqueUuid
 
   enum type: {
-    create_ecosystem: 0
+    no_op:            -1,
+    create_ecosystem:  0
   }
 
   validates :type,            presence: true

--- a/spec/domain/services/fetch_course_metadatas/service_spec.rb
+++ b/spec/domain/services/fetch_course_metadatas/service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Services::FetchCourseMetadatas::Service, type: :service do
   let(:service)              { described_class.new }
-  let(:action)               { service.process() }
+  let(:action)               { service.process     }
 
   context "when there are no courses" do
     it "returns an empty array" do
@@ -14,13 +14,13 @@ RSpec.describe Services::FetchCourseMetadatas::Service, type: :service do
     let(:courses_count)      { rand(10) + 1 }
 
     let!(:courses)           do
-      FactoryGirl.create_list(:course_event, courses_count, {
+      FactoryGirl.create_list(
+        :course_event,
+        courses_count,
         type: :create_course,
         sequence_number: 0,
-        data: {
-          ecosystem_uuid: SecureRandom.uuid
-        }
-      })
+        data: { ecosystem_uuid: SecureRandom.uuid }
+      )
     end
 
     let(:expected_responses) do

--- a/spec/domain/services/fetch_ecosystem_metadatas/service_spec.rb
+++ b/spec/domain/services/fetch_ecosystem_metadatas/service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Services::FetchEcosystemMetadatas::Service, type: :service do
   let(:service)              { described_class.new }
-  let(:action)               { service.process() }
+  let(:action)               { service.process     }
 
   context "when there are no ecosystems" do
     it "returns an empty array" do
@@ -13,7 +13,14 @@ RSpec.describe Services::FetchEcosystemMetadatas::Service, type: :service do
   context "when there are ecosystems" do
     let(:ecosystems_count)   { rand(10) + 1 }
 
-    let!(:ecosystems)        { FactoryGirl.create_list :ecosystem_event, ecosystems_count }
+    let!(:ecosystems)        do
+      FactoryGirl.create_list(
+        :ecosystem_event,
+        ecosystems_count,
+        type: :create_ecosystem,
+        sequence_number: 0
+      )
+    end
 
     let(:expected_responses) do
       ecosystems.map { |ecosystem| { uuid: ecosystem[:ecosystem_uuid] } }


### PR DESCRIPTION
These do nothing and can be used to fill sequence number gaps.
Adding them here so we can create and query them more easily.