### PR TITLE
scout_ignore more high volume requests

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -17,6 +17,7 @@ class CoursesController < JsonApiController
   end
 
   def fetch_metadatas
+    scout_ignore! 0.99
     respond_with_json_apis_and_service(
       output_schema: _fetch_metadatas_response_payload_schema,
       service: Services::FetchCourseMetadatas::Service
@@ -24,6 +25,7 @@ class CoursesController < JsonApiController
   end
 
   def fetch_events
+    scout_ignore! 0.99
     respond_with_json_apis_and_service(
       input_schema:  _fetch_events_request_payload_schema,
       output_schema: _fetch_events_response_payload_schema,


### PR DESCRIPTION
Reduces the amount of data we send to our application monitoring application (so we don't go past what we pay for)