### PR TITLE
Optimize the event queries further by splitting them into 2

### DIFF
--- a/app/domain/services/fetch_course_events/service.rb
+++ b/app/domain/services/fetch_course_events/service.rb
@@ -13,70 +13,97 @@ class Services::FetchCourseEvents::Service < Services::ApplicationService
         request.fetch(:request_uuid)
       ]
     end
-    course_event_join_query = <<-JOIN_SQL.strip_heredoc
-      RIGHT OUTER JOIN (#{ValuesTable.new(course_event_values_array)})
-        AS "requests" ("course_uuid", "sequence_number_offset", "event_types", "request_uuid")
-        ON "courses"."uuid" = "requests"."course_uuid"::uuid
-          AND "courses"."sequence_number" > "requests"."sequence_number_offset"
-          AND "course_events"."sequence_number" >= "requests"."sequence_number_offset"
-          AND "course_events"."type" = ANY ("requests"."event_types")
-      WINDOW "window" AS (
-        ORDER BY "course_events"."sequence_number" - "requests"."sequence_number_offset"
-          ASC NULLS FIRST
-        ROWS UNBOUNDED PRECEDING
-      )
-    JOIN_SQL
+    active_course_uuids = Set.new Course.joins(
+      <<-JOIN_SQL.strip_heredoc
+        INNER JOIN (#{ValuesTable.new(course_event_values_array)})
+          AS "requests" ("course_uuid", "sequence_number_offset", "event_types", "request_uuid")
+          ON "courses"."uuid" = "requests"."course_uuid"::uuid
+            AND "courses"."sequence_number" > "requests"."sequence_number_offset"
+      JOIN_SQL
+    ).pluck(:uuid)
 
-    # Also return gap information about each record
-    course_events = CourseEvent
-      .from("(#{
-        CourseEvent.select(
-          <<-SELECT_SQL.strip_heredoc
-            "course_events"."sequence_number",
-            "course_events"."uuid",
-            "course_events"."type",
-            "course_events"."data",
-            ROW_NUMBER() OVER "window" AS "row_number",
-            SUM(BIT_LENGTH("course_events"."data"::text)) OVER "window" AS "cumulative_size",
-            CASE WHEN "course_events"."sequence_number" > 0
-              AND NOT EXISTS (
-                SELECT "previous_event".*
-                FROM "course_events" AS "previous_event"
-                WHERE "previous_event"."course_uuid" = "course_events"."course_uuid"
-                  AND "previous_event"."sequence_number" = "course_events"."sequence_number" - 1
+    unless active_course_uuids.empty?
+      active_course_event_values = course_event_values_array.select do |course_event_value|
+        active_course_uuids.include? course_event_value.first
+      end
+
+      # Also return gap information about each record
+      course_events = CourseEvent
+        .from("(#{
+          CourseEvent.select(
+            <<-SELECT_SQL.strip_heredoc
+              "course_events"."sequence_number",
+              "course_events"."uuid",
+              "course_events"."type",
+              "course_events"."data",
+              ROW_NUMBER() OVER "window" AS "row_number",
+              SUM(BIT_LENGTH("course_events"."data"::text)) OVER "window" AS "cumulative_size",
+              CASE WHEN "course_events"."sequence_number" > 0
+                AND NOT EXISTS (
+                  SELECT "previous_event".*
+                  FROM "course_events" AS "previous_event"
+                  WHERE "previous_event"."course_uuid" = "course_events"."course_uuid"
+                    AND "previous_event"."sequence_number" = "course_events"."sequence_number" - 1
+                ) THEN TRUE
+              ELSE FALSE
+              END AS "is_after_gap",
+              CASE WHEN NOT EXISTS (
+                SELECT "next_events".*
+                FROM "course_events" AS "next_events"
+                WHERE "next_events"."course_uuid" = "course_events"."course_uuid"
+                  AND "next_events"."sequence_number" > "course_events"."sequence_number"
+                  AND "next_events"."type" = ANY("requests"."event_types")
               ) THEN TRUE
-            ELSE FALSE
-            END AS "is_after_gap",
-            CASE WHEN NOT EXISTS (
-              SELECT "next_events".*
-              FROM "course_events" AS "next_events"
-              WHERE "next_events"."course_uuid" = "course_events"."course_uuid"
-                AND "next_events"."sequence_number" > "course_events"."sequence_number"
-                AND "next_events"."type" = ANY ("requests"."event_types")
-            ) THEN TRUE
-            ELSE FALSE
-            END AS "is_end",
-            "requests"."request_uuid"
-          SELECT_SQL
+              ELSE FALSE
+              END AS "is_end",
+              "requests"."request_uuid"
+            SELECT_SQL
+          )
+          .joins(
+            <<-JOIN_SQL.strip_heredoc
+              RIGHT OUTER JOIN (#{ValuesTable.new(active_course_event_values)}) AS "requests"
+                ("course_uuid", "sequence_number_offset", "event_types", "request_uuid")
+                ON "course_events"."course_uuid" = "requests"."course_uuid"::uuid
+                  AND "course_events"."sequence_number" >= "requests"."sequence_number_offset"
+                  AND "course_events"."type" = ANY("requests"."event_types")
+              WINDOW "window" AS (
+                ORDER BY "course_events"."sequence_number" - "requests"."sequence_number_offset"
+                  ASC NULLS FIRST
+                ROWS UNBOUNDED PRECEDING
+              )
+            JOIN_SQL
+          )
+          .order(
+            <<-ORDER_SQL.strip_heredoc
+              "course_events"."sequence_number" - "requests"."sequence_number_offset"
+              ASC NULLS FIRST
+            ORDER_SQL
+          )
+          .limit(max_num_events)
+          .to_sql
+        }) AS \"course_events\"")
+        .where(
+          <<-WHERE_SQL.strip_heredoc
+            "row_number" = 1
+              OR "cumulative_size" IS NULL
+              OR "cumulative_size" < #{MAX_DATA_SIZE.to_i}
+          WHERE_SQL
         )
-        .joins(:course)
-        .joins(course_event_join_query)
-        .order(
-          '"course_events"."sequence_number" - "requests"."sequence_number_offset" ASC NULLS FIRST'
-        )
-        .limit(max_num_events)
-        .to_sql
-      }) AS \"course_events\"")
-      .where(
-        <<-WHERE_SQL.strip_heredoc
-          "row_number" = 1 OR "cumulative_size" IS NULL OR "cumulative_size" < #{MAX_DATA_SIZE.to_i}
-        WHERE_SQL
-      )
-    course_events_by_request_uuid = course_events.group_by(&:request_uuid)
+      course_events_by_request_uuid = course_events.group_by(&:request_uuid)
+    end
 
     responses = course_event_requests.map do |request|
       request_uuid = request.fetch(:request_uuid)
       course_uuid = request.fetch(:course_uuid)
+
+      # Inactive course
+      next {
+        request_uuid: request_uuid,
+        course_uuid: course_uuid,
+        events: [],
+        is_gap: false,
+        is_end: true
+      } unless active_course_uuids.include? course_uuid
 
       # Limit reached before the first row for this request could be processed
       next {


### PR DESCRIPTION
Prevents the planner from taking too long planning or picking suboptimal execution strategies.