### PR TITLE
disallow null values in the course initial_ecosystem_uuid column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore rubymine files
+.idea
+
 # Ignore Byebug command history file.
 .byebug_history
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,6 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
-
-# See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'therubyracer', platforms: :ruby
-
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,13 +53,6 @@ GEM
     byebug (9.0.6)
     choice (0.2.0)
     coderay (1.1.1)
-    coffee-rails (4.2.1)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.2.x)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     database_cleaner (1.5.3)
@@ -108,7 +101,6 @@ GEM
     json-schema (2.8.0)
       addressable (>= 2.4)
     kgio (2.11.0)
-    libv8 (3.16.14.15)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -182,7 +174,6 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rb-readline (0.5.5)
-    ref (2.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -234,9 +225,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -273,7 +261,6 @@ DEPENDENCIES
   activerecord-import
   aws-ses
   byebug
-  coffee-rails (~> 4.2)
   database_cleaner
   factory_girl_rails
   faker
@@ -300,7 +287,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
-  therubyracer
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   unicorn-rails
@@ -308,4 +294,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/app/controllers/course_ecosystems_controller.rb
+++ b/app/controllers/course_ecosystems_controller.rb
@@ -135,6 +135,7 @@ class CourseEcosystemsController < JsonApiController
           'properties': {
             'request_uuid':     {'$ref': '#standard_definitions/uuid'},
             'course_uuid':      {'$ref': '#standard_definitions/uuid'},
+            'ecosystem_uuid':   {'$ref': '#standard_definitions/uuid'},
             'sequence_number':  {'$ref': '#standard_definitions/non_negative_integer'},
             'preparation_uuid': {'$ref': '#standard_definitions/uuid'},
             'updated_at':       {'$ref': '#/standard_definitions/datetime'}
@@ -142,6 +143,7 @@ class CourseEcosystemsController < JsonApiController
           'required': [
             'request_uuid',
             'course_uuid',
+            'ecosystem_uuid',
             'sequence_number',
             'preparation_uuid',
             'updated_at'

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -88,6 +88,7 @@ class CoursesController < JsonApiController
       'properties': {
         'request_uuid':    {'$ref': '#standard_definitions/uuid'},
         'course_uuid':     {'$ref': '#/standard_definitions/uuid'},
+        'ecosystem_uuid':  {'$ref': '#/standard_definitions/uuid'},
         'sequence_number': {'$ref': '#/standard_definitions/non_negative_integer'},
         'starts_at':       {'$ref': '#/standard_definitions/datetime'},
         'ends_at':         {'$ref': '#/standard_definitions/datetime'},
@@ -96,6 +97,7 @@ class CoursesController < JsonApiController
       'required': [
         'request_uuid',
         'course_uuid',
+        'ecosystem_uuid',
         'sequence_number',
         'starts_at',
         'ends_at',

--- a/app/controllers/exercise_exclusions_controller.rb
+++ b/app/controllers/exercise_exclusions_controller.rb
@@ -26,6 +26,7 @@ class ExerciseExclusionsController < JsonApiController
       'properties': {
         'request_uuid':    {'$ref': '#/standard_definitions/uuid'},
         'course_uuid':     {'$ref': '#/standard_definitions/uuid'},
+        'ecosystem_uuid':  {'$ref': '#/standard_definitions/uuid'},
         'sequence_number': {'$ref': '#/standard_definitions/non_negative_integer'},
         'exclusions': {
           'type': 'array',
@@ -35,7 +36,12 @@ class ExerciseExclusionsController < JsonApiController
         },
         'updated_at': {'$ref': '#/standard_definitions/datetime'}
       },
-      'required': ['request_uuid', 'course_uuid', 'sequence_number', 'exclusions', 'updated_at'],
+      'required': ['request_uuid',
+                   'course_uuid',
+                   'ecosystem_uuid',
+                   'sequence_number',
+                   'exclusions',
+                   'updated_at'],
       'additionalProperties': false,
       'standard_definitions': _standard_definitions
     }
@@ -64,6 +70,7 @@ class ExerciseExclusionsController < JsonApiController
       'properties': {
         'request_uuid':    {'$ref': '#/standard_definitions/uuid'},
         'course_uuid':     {'$ref': '#/standard_definitions/uuid'},
+        'ecosystem_uuid':  {'$ref': '#/standard_definitions/uuid'},
         'sequence_number': {'$ref': '#/standard_definitions/non_negative_integer'},
         'exclusions': {
           'type': 'array',
@@ -73,7 +80,12 @@ class ExerciseExclusionsController < JsonApiController
         },
         'updated_at': {'$ref': '#/standard_definitions/datetime'}
       },
-      'required': ['request_uuid', 'course_uuid', 'sequence_number', 'exclusions', 'updated_at'],
+      'required': ['request_uuid',
+                   'course_uuid',
+                   'ecosystem_uuid',
+                   'sequence_number',
+                   'exclusions',
+                   'updated_at'],
       'additionalProperties': false,
       'standard_definitions': _standard_definitions
     }

--- a/app/domain/services/create_update_assignments/service.rb
+++ b/app/domain/services/create_update_assignments/service.rb
@@ -11,6 +11,9 @@ class Services::CreateUpdateAssignments::Service < Services::ApplicationService
         type: :create_update_assignment,
         course_uuid: assignment.fetch(:course_uuid),
         sequence_number: assignment.fetch(:sequence_number),
+        sequence_number_association_extra_attributes: {
+          initial_ecosystem_uuid: assignment.fetch(:ecosystem_uuid),
+        },
         data: assignment.slice(
           :request_uuid,
           :course_uuid,

--- a/app/domain/services/prepare_course_ecosystem/service.rb
+++ b/app/domain/services/prepare_course_ecosystem/service.rb
@@ -6,6 +6,9 @@ class Services::PrepareCourseEcosystem::Service < Services::ApplicationService
       uuid: preparation_uuid,
       course_uuid: course_uuid,
       sequence_number: sequence_number,
+      sequence_number_association_extra_attributes: {
+        initial_ecosystem_uuid: next_ecosystem_uuid,
+      },
       data: {
         preparation_uuid: preparation_uuid,
         course_uuid: course_uuid,

--- a/app/domain/services/record_responses/service.rb
+++ b/app/domain/services/record_responses/service.rb
@@ -8,6 +8,9 @@ class Services::RecordResponses::Service < Services::ApplicationService
         type: :record_response,
         course_uuid: response.fetch(:course_uuid),
         sequence_number: response.fetch(:sequence_number),
+        sequence_number_association_extra_attributes: {
+            initial_ecosystem_uuid: response.fetch(:ecosystem_uuid),
+        },
         data: response.slice(
           :response_uuid,
           :course_uuid,

--- a/app/domain/services/update_course_active_dates/service.rb
+++ b/app/domain/services/update_course_active_dates/service.rb
@@ -1,10 +1,13 @@
 class Services::UpdateCourseActiveDates::Service < Services::ApplicationService
-  def process(request_uuid:, course_uuid:, sequence_number:, starts_at:, ends_at:, updated_at:)
+  def process(request_uuid:, course_uuid:, ecosystem_uuid:, sequence_number:, starts_at:, ends_at:, updated_at:)
     CourseEvent.append(
       uuid: request_uuid,
       type: :update_course_active_dates,
       course_uuid: course_uuid,
       sequence_number: sequence_number,
+      sequence_number_association_extra_attributes: {
+        initial_ecosystem_uuid: ecosystem_uuid,
+      },
       data: {
         request_uuid: request_uuid,
         course_uuid: course_uuid,

--- a/app/domain/services/update_course_ecosystem/service.rb
+++ b/app/domain/services/update_course_ecosystem/service.rb
@@ -22,6 +22,9 @@ class Services::UpdateCourseEcosystem::Service < Services::ApplicationService
             type: :update_course_ecosystem,
             course_uuid: request.fetch(:course_uuid),
             sequence_number: request.fetch(:sequence_number),
+            sequence_number_association_extra_attributes: {
+              initial_ecosystem_uuid: request.fetch(:course_ecosystem_uuid),
+            },
             data: request.slice(
               :request_uuid,
               :course_uuid,

--- a/app/domain/services/update_course_exercise_exclusions/service.rb
+++ b/app/domain/services/update_course_exercise_exclusions/service.rb
@@ -1,10 +1,13 @@
 class Services::UpdateCourseExerciseExclusions::Service < Services::ApplicationService
-  def process(request_uuid:, course_uuid:, sequence_number:, exclusions:, updated_at:)
+  def process(request_uuid:, course_uuid:, ecosystem_uuid:, sequence_number:, exclusions:, updated_at:)
     CourseEvent.append(
       uuid:            request_uuid,
       type:            :update_course_excluded_exercises,
       course_uuid:     course_uuid,
       sequence_number: sequence_number,
+      sequence_number_association_extra_attributes: {
+        initial_ecosystem_uuid: ecosystem_uuid,
+      },
       data:            {
         request_uuid: request_uuid,
         course_uuid:     course_uuid,

--- a/app/domain/services/update_global_exercise_exclusions/service.rb
+++ b/app/domain/services/update_global_exercise_exclusions/service.rb
@@ -1,10 +1,13 @@
 class Services::UpdateGlobalExerciseExclusions::Service < Services::ApplicationService
-  def process(request_uuid:, course_uuid:, sequence_number:, exclusions:, updated_at:)
+  def process(request_uuid:, course_uuid:, sequence_number:, ecosystem_uuid:, exclusions:, updated_at:)
     CourseEvent.append(
       uuid:            request_uuid,
       type:            :update_globally_excluded_exercises,
       course_uuid:     course_uuid,
       sequence_number: sequence_number,
+      sequence_number_association_extra_attributes: {
+        initial_ecosystem_uuid: ecosystem_uuid,
+      },
       data:            {
         request_uuid: request_uuid,
         course_uuid:     course_uuid,

--- a/app/domain/services/update_rosters/service.rb
+++ b/app/domain/services/update_rosters/service.rb
@@ -11,13 +11,16 @@ class Services::UpdateRosters::Service < Services::ApplicationService
       roster.fetch(:students).each do |student|
         student_attributes << { uuid: student.fetch(:student_uuid) }
       end
-
+      course = Course.find_by(uuid: roster.fetch(:course_uuid))
       course_event_attributes << {
         # No appropriate uuid in the request to use here
-        uuid: roster.fetch(:request_uuid),
+        uuid: course.uuid,
         type: :update_roster,
         course_uuid: roster.fetch(:course_uuid),
         sequence_number: roster.fetch(:sequence_number),
+        sequence_number_association_extra_attributes: {
+            initial_ecosystem_uuid: course.initial_ecosystem_uuid,
+        },
         data: roster.slice(
           :request_uuid,
           :course_uuid,

--- a/app/models/concerns/append_only_with_unique_uuid.rb
+++ b/app/models/concerns/append_only_with_unique_uuid.rb
@@ -59,6 +59,7 @@ module AppendOnlyWithUniqueUuid
         end
         conflict_columns_sql_array << '"updated_at" = EXCLUDED."updated_at"'
         conflict_columns_sql = conflict_columns_sql_array.join(', ')
+
         sequence_number_association_class.import default_columns + extra_columns.to_a,
                                                  sequence_number_association_records_to_import,
                                                  validate: false, on_duplicate_key_update: {

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,6 +6,7 @@ class Course < ApplicationRecord
                            foreign_key: :course_uuid,
                            inverse_of: :course
 
+  validates :initial_ecosystem_uuid, presence: true
   validates :sequence_number,
             presence: true,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/db/migrate/20190114195540_non_null_course_ecosystem.rb
+++ b/db/migrate/20190114195540_non_null_course_ecosystem.rb
@@ -1,0 +1,5 @@
+class NonNullCourseEcosystem < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :courses, :initial_ecosystem_uuid, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181112182803) do
+ActiveRecord::Schema.define(version: 20190114195540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,7 +104,7 @@ ActiveRecord::Schema.define(version: 20181112182803) do
     t.uuid     "uuid",                                                                               null: false
     t.integer  "metadata_sequence_number", default: -> { "next_course_metadata_sequence_number()" }, null: false
     t.integer  "sequence_number",                                                                    null: false
-    t.uuid     "initial_ecosystem_uuid"
+    t.uuid     "initial_ecosystem_uuid",                                                             null: false
     t.datetime "created_at",                                                                         null: false
     t.datetime "updated_at",                                                                         null: false
     t.index ["metadata_sequence_number"], name: "index_courses_on_metadata_sequence_number", unique: true, using: :btree

--- a/spec/controllers/courses_controller/controller_spec.rb
+++ b/spec/controllers/courses_controller/controller_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe CoursesController, type: :request do
   context '#update_course_active_dates' do
     let(:given_request_uuid)    { SecureRandom.uuid }
     let(:given_course_uuid)     { SecureRandom.uuid }
+    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) }
     let(:given_starts_at)       { Time.current.yesterday.iso8601(6) }
     let(:given_ends_at)         { Time.current.tomorrow.iso8601(6) }
@@ -64,6 +65,7 @@ RSpec.describe CoursesController, type: :request do
       {
         request_uuid: given_request_uuid,
         course_uuid: given_course_uuid,
+        ecosystem_uuid: given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         starts_at: given_starts_at,
         ends_at: given_ends_at,

--- a/spec/controllers/exercise_exclusions_controller/controller_spec.rb
+++ b/spec/controllers/exercise_exclusions_controller/controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ExerciseExclusionsController, type: :request do
   context '#update_course_excluded_exercises' do
     let(:given_course_uuid)     { SecureRandom.uuid }
     let(:given_request_uuid)    { SecureRandom.uuid }
+    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) }
     let(:number_of_exclusions)  { 10 }
 
@@ -25,6 +26,7 @@ RSpec.describe ExerciseExclusionsController, type: :request do
       {
         request_uuid:    given_request_uuid,
         course_uuid:     given_course_uuid,
+        ecosystem_uuid:  given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         exclusions:      given_exclusions,
         updated_at:      given_updated_at
@@ -79,6 +81,7 @@ RSpec.describe ExerciseExclusionsController, type: :request do
   context '#update_globally_excluded_exercises' do
     let(:given_request_uuid)    { SecureRandom.uuid }
     let(:given_course_uuid)     { SecureRandom.uuid }
+    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) }
     let(:number_of_exclusions)  { 10 }
 
@@ -100,6 +103,7 @@ RSpec.describe ExerciseExclusionsController, type: :request do
       {
         request_uuid:    given_request_uuid,
         course_uuid:     given_course_uuid,
+        ecosystem_uuid:  given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         exclusions:      given_exclusions,
         updated_at:      given_updated_at

--- a/spec/domain/services/create_update_assignments/service_spec.rb
+++ b/spec/domain/services/create_update_assignments/service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Services::CreateUpdateAssignments::Service, type: :service do
     ]
   end
 
-  let(:action)                                  { service.process(assignments: given_assignments) }
+  let(:action) { service.process(assignments: given_assignments) }
 
   context "when a previously-existing course_uuid and sequence_number combo is given" do
     before(:each) do

--- a/spec/domain/services/update_course_active_dates/service_spec.rb
+++ b/spec/domain/services/update_course_active_dates/service_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Services::UpdateCourseActiveDates::Service, type: :service do
 
   let(:given_request_uuid)    { SecureRandom.uuid }
   let(:given_course_uuid)     { SecureRandom.uuid }
+  let(:given_ecosystem_uuid)  { SecureRandom.uuid }
   let(:given_sequence_number) { rand(10) }
   let(:given_starts_at)       { Time.current.yesterday.iso8601(6) }
   let(:given_ends_at)         { Time.current.tomorrow.iso8601(6)  }
@@ -14,6 +15,7 @@ RSpec.describe Services::UpdateCourseActiveDates::Service, type: :service do
     service.process(
       request_uuid: given_request_uuid,
       course_uuid: given_course_uuid,
+      ecosystem_uuid: given_ecosystem_uuid,
       sequence_number: given_sequence_number,
       starts_at: given_starts_at,
       ends_at: given_ends_at,

--- a/spec/domain/services/update_course_ecosystem/service_spec.rb
+++ b/spec/domain/services/update_course_ecosystem/service_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe Services::UpdateCourseEcosystem::Service, type: :service do
   let(:given_sequence_number)  { rand(1000) }
   let(:given_preparation_uuid) { SecureRandom.uuid }
   let(:given_updated_at)       { Time.current.iso8601(6) }
+  let(:given_course_ecosystem_uuid) { SecureRandom.uuid }
 
   let(:given_update_requests)  do
     [
       {
         request_uuid: given_request_uuid,
         course_uuid: given_course_uuid,
+        course_ecosystem_uuid: given_course_ecosystem_uuid,
         sequence_number: given_sequence_number,
         preparation_uuid: given_preparation_uuid,
         updated_at: given_updated_at

--- a/spec/domain/services/update_rosters/service_spec.rb
+++ b/spec/domain/services/update_rosters/service_spec.rb
@@ -91,10 +91,9 @@ RSpec.describe Services::UpdateRosters::Service, type: :service do
 
   context "when a previously-existing course_uuid and sequence_number combination is given" do
       before(:each) do
-          p given_course
-      FactoryGirl.create :course_event,
-                         course_uuid: given_course_uuid,
-                         sequence_number: given_sequence_number
+        FactoryGirl.create :course_event,
+                           course_uuid: given_course_uuid,
+                           sequence_number: given_sequence_number
     end
 
     it "a CourseEvent is NOT created and an error is returned" do

--- a/spec/domain/services/update_rosters/service_spec.rb
+++ b/spec/domain/services/update_rosters/service_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Services::UpdateRosters::Service, type: :service do
   let(:service)                                        { described_class.new }
 
   let(:given_request_uuid)                             { SecureRandom.uuid }
-  let(:given_course_uuid)                              { SecureRandom.uuid }
+  let(:given_course)                                   { FactoryGirl.create :course }
+  let(:given_course_uuid)                              { given_course.uuid }
   let(:given_sequence_number)                          { rand(10) }
 
   let(:given_course_container_1_uuid)                  { SecureRandom.uuid }
@@ -89,7 +90,8 @@ RSpec.describe Services::UpdateRosters::Service, type: :service do
   let(:action)                                         { service.process(rosters: given_rosters) }
 
   context "when a previously-existing course_uuid and sequence_number combination is given" do
-    before(:each) do
+      before(:each) do
+          p given_course
       FactoryGirl.create :course_event,
                          course_uuid: given_course_uuid,
                          sequence_number: given_sequence_number

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :course do
     uuid                   { SecureRandom.uuid }
     sequence_number        0
-
+    initial_ecosystem_uuid { SecureRandom.uuid }
     after(:create) { |course| course.reload }
   end
 end

--- a/spec/models/concerns/append_only_with_unique_uuid_spec.rb
+++ b/spec/models/concerns/append_only_with_unique_uuid_spec.rb
@@ -4,6 +4,20 @@ RSpec.describe AppendOnlyWithUniqueUuid, type: :concern do
   let(:test_class)    { CourseEvent }
 
   let(:test_instance) { FactoryGirl.build(:course_event) }
+  let(:event_1_attributes) {
+      FactoryGirl.build(:course_event).attributes.merge(
+          sequence_number_association_extra_attributes: {
+              initial_ecosystem_uuid: SecureRandom.uuid,
+          }
+      )
+  }
+  let(:event_2_attributes) {
+      FactoryGirl.build(:course_event).attributes.merge(
+          sequence_number_association_extra_attributes: {
+              initial_ecosystem_uuid: SecureRandom.uuid,
+          }
+      )
+  }
 
   it 'makes instances of the including class append-only' do
     expect(test_instance.new_record?).to eq true
@@ -18,16 +32,14 @@ RSpec.describe AppendOnlyWithUniqueUuid, type: :concern do
   end
 
   it 'can import multiple records through append' do
-    event_1_attributes = FactoryGirl.build(:course_event).attributes
-    event_2_attributes = FactoryGirl.build(:course_event).attributes
     attributes_array = [ event_1_attributes, event_2_attributes ]
-
     expect{test_class.append attributes_array}.to change{test_class.count}.by(2)
     expect{test_class.append attributes_array}.not_to change{test_class.count}
 
     # We expect the import to explode if the same course_uuid and sequence_number
     # are used with a different event uuid
     conflicting_attributes = [event_1_attributes.merge('uuid' => SecureRandom.uuid)]
+
     expect{test_class.append conflicting_attributes}.to(
       raise_error(ActiveRecord::RecordNotUnique)
     )
@@ -37,17 +49,29 @@ RSpec.describe AppendOnlyWithUniqueUuid, type: :concern do
     course_uuid = SecureRandom.uuid
     event_1_attributes = FactoryGirl.build(
       :course_event, course: nil, course_uuid: course_uuid, sequence_number: 0
-    ).attributes
+    ).attributes.merge(
+          sequence_number_association_extra_attributes: {
+              initial_ecosystem_uuid: SecureRandom.uuid,
+          }
+      )
     expect{ test_class.append [ event_1_attributes ] }.to change { Course.count }.by(1)
     course = Course.find_by! uuid: course_uuid
     expect(course.sequence_number).to eq 1
 
     event_2_attributes = FactoryGirl.build(
       :course_event, course: course, sequence_number: 1
-    ).attributes
+    ).attributes.merge(
+          sequence_number_association_extra_attributes: {
+              initial_ecosystem_uuid: SecureRandom.uuid,
+          }
+      )
     event_3_attributes = FactoryGirl.build(
       :course_event, course: course, sequence_number: 3
-    ).attributes
+    ).attributes.merge(
+          sequence_number_association_extra_attributes: {
+              initial_ecosystem_uuid: SecureRandom.uuid,
+          }
+      )
     attributes_array = [ event_2_attributes, event_3_attributes ]
 
     expect{ test_class.append attributes_array }.to(
@@ -56,7 +80,11 @@ RSpec.describe AppendOnlyWithUniqueUuid, type: :concern do
 
     event_4_attributes = FactoryGirl.build(
       :course_event, course: course, sequence_number: 2
-    ).attributes
+    ).attributes.merge(
+          sequence_number_association_extra_attributes: {
+              initial_ecosystem_uuid: SecureRandom.uuid,
+          }
+      )
 
     expect{ test_class.append [ event_4_attributes ] }.not_to(
       change { course.reload.sequence_number }

--- a/spec/support/exercise_exclusions_services_shared_examples.rb
+++ b/spec/support/exercise_exclusions_services_shared_examples.rb
@@ -7,6 +7,7 @@ module ExerciseExclusionsServicesSharedExamples
 
     let(:given_request_uuid)    { SecureRandom.uuid }
     let(:given_course_uuid)     { SecureRandom.uuid }
+    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) + 1 }
     let(:given_exclusions)      { generate_exclusions(number_of_exclusions) }
     let(:given_updated_at)      { Time.current.iso8601(6) }
@@ -15,6 +16,7 @@ module ExerciseExclusionsServicesSharedExamples
       service.process(
         request_uuid: given_request_uuid,
         course_uuid: given_course_uuid,
+        ecosystem_uuid: given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         exclusions: given_exclusions,
         updated_at: given_updated_at
@@ -121,12 +123,16 @@ module ExerciseExclusionsServicesSharedExamples
 
   def save_preexisting_exclusions(type, course_uuid, generated_exclusions)
     request_uuid = SecureRandom.uuid
+    ecosystem_uuid = SecureRandom.uuid
 
     CourseEvent.append(
       uuid: request_uuid,
       type: type,
       course_uuid: course_uuid,
       sequence_number: 0,
+      sequence_number_association_extra_attributes: {
+        initial_ecosystem_uuid: ecosystem_uuid,
+      },
       data: {
         request_uuid: request_uuid,
         exclusions: generated_exclusions


### PR DESCRIPTION
currently we have no null values in production,🤞 that remains the case until this is deployed

This PR has a commit https://github.com/openstax/biglearn-api/pull/85/commits/bb36b5e0ae0f1f130c46ce5c49dd814ea2e616e9#diff-c7714fa5a0126377650c49cf0cb091ddR26 that needs to be fixed in Tutor at the same time.  This commit was required to send in a ecosystem guid so that the new Course constraint can be satisfied.  