### PR TITLE
Remove ecosystem UUID from non create apis

### DIFF
--- a/app/controllers/course_ecosystems_controller.rb
+++ b/app/controllers/course_ecosystems_controller.rb
@@ -135,7 +135,6 @@ class CourseEcosystemsController < JsonApiController
           'properties': {
             'request_uuid':     {'$ref': '#standard_definitions/uuid'},
             'course_uuid':      {'$ref': '#standard_definitions/uuid'},
-            'ecosystem_uuid':   {'$ref': '#standard_definitions/uuid'},
             'sequence_number':  {'$ref': '#standard_definitions/non_negative_integer'},
             'preparation_uuid': {'$ref': '#standard_definitions/uuid'},
             'updated_at':       {'$ref': '#/standard_definitions/datetime'}
@@ -143,7 +142,6 @@ class CourseEcosystemsController < JsonApiController
           'required': [
             'request_uuid',
             'course_uuid',
-            'ecosystem_uuid',
             'sequence_number',
             'preparation_uuid',
             'updated_at'

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -88,7 +88,6 @@ class CoursesController < JsonApiController
       'properties': {
         'request_uuid':    {'$ref': '#standard_definitions/uuid'},
         'course_uuid':     {'$ref': '#/standard_definitions/uuid'},
-        'ecosystem_uuid':  {'$ref': '#/standard_definitions/uuid'},
         'sequence_number': {'$ref': '#/standard_definitions/non_negative_integer'},
         'starts_at':       {'$ref': '#/standard_definitions/datetime'},
         'ends_at':         {'$ref': '#/standard_definitions/datetime'},
@@ -97,7 +96,6 @@ class CoursesController < JsonApiController
       'required': [
         'request_uuid',
         'course_uuid',
-        'ecosystem_uuid',
         'sequence_number',
         'starts_at',
         'ends_at',

--- a/app/controllers/exercise_exclusions_controller.rb
+++ b/app/controllers/exercise_exclusions_controller.rb
@@ -26,7 +26,6 @@ class ExerciseExclusionsController < JsonApiController
       'properties': {
         'request_uuid':    {'$ref': '#/standard_definitions/uuid'},
         'course_uuid':     {'$ref': '#/standard_definitions/uuid'},
-        'ecosystem_uuid':  {'$ref': '#/standard_definitions/uuid'},
         'sequence_number': {'$ref': '#/standard_definitions/non_negative_integer'},
         'exclusions': {
           'type': 'array',
@@ -36,12 +35,13 @@ class ExerciseExclusionsController < JsonApiController
         },
         'updated_at': {'$ref': '#/standard_definitions/datetime'}
       },
-      'required': ['request_uuid',
-                   'course_uuid',
-                   'ecosystem_uuid',
-                   'sequence_number',
-                   'exclusions',
-                   'updated_at'],
+      'required': [
+        'request_uuid',
+        'course_uuid',
+        'sequence_number',
+        'exclusions',
+        'updated_at'
+      ],
       'additionalProperties': false,
       'standard_definitions': _standard_definitions
     }
@@ -70,7 +70,6 @@ class ExerciseExclusionsController < JsonApiController
       'properties': {
         'request_uuid':    {'$ref': '#/standard_definitions/uuid'},
         'course_uuid':     {'$ref': '#/standard_definitions/uuid'},
-        'ecosystem_uuid':  {'$ref': '#/standard_definitions/uuid'},
         'sequence_number': {'$ref': '#/standard_definitions/non_negative_integer'},
         'exclusions': {
           'type': 'array',
@@ -80,12 +79,13 @@ class ExerciseExclusionsController < JsonApiController
         },
         'updated_at': {'$ref': '#/standard_definitions/datetime'}
       },
-      'required': ['request_uuid',
-                   'course_uuid',
-                   'ecosystem_uuid',
-                   'sequence_number',
-                   'exclusions',
-                   'updated_at'],
+      'required': [
+        'request_uuid',
+        'course_uuid',
+        'sequence_number',
+        'exclusions',
+        'updated_at'
+      ],
       'additionalProperties': false,
       'standard_definitions': _standard_definitions
     }

--- a/app/domain/services/create_update_assignments/service.rb
+++ b/app/domain/services/create_update_assignments/service.rb
@@ -11,9 +11,6 @@ class Services::CreateUpdateAssignments::Service < Services::ApplicationService
         type: :create_update_assignment,
         course_uuid: assignment.fetch(:course_uuid),
         sequence_number: assignment.fetch(:sequence_number),
-        sequence_number_association_extra_attributes: {
-          initial_ecosystem_uuid: assignment.fetch(:ecosystem_uuid),
-        },
         data: assignment.slice(
           :request_uuid,
           :course_uuid,

--- a/app/domain/services/fetch_course_metadatas/service.rb
+++ b/app/domain/services/fetch_course_metadatas/service.rb
@@ -3,6 +3,7 @@ class Services::FetchCourseMetadatas::Service < Services::ApplicationService
     cc = Course.arel_table
     courses = Course
       .where(cc[:metadata_sequence_number].gteq(metadata_sequence_number_offset))
+      .where(cc[:initial_ecosystem_uuid].not_eq(nil))
       .order(:metadata_sequence_number)
       .limit(max_num_metadatas)
       .pluck_with_keys(:uuid, :initial_ecosystem_uuid, :metadata_sequence_number)

--- a/app/domain/services/prepare_course_ecosystem/service.rb
+++ b/app/domain/services/prepare_course_ecosystem/service.rb
@@ -6,9 +6,6 @@ class Services::PrepareCourseEcosystem::Service < Services::ApplicationService
       uuid: preparation_uuid,
       course_uuid: course_uuid,
       sequence_number: sequence_number,
-      sequence_number_association_extra_attributes: {
-        initial_ecosystem_uuid: next_ecosystem_uuid,
-      },
       data: {
         preparation_uuid: preparation_uuid,
         course_uuid: course_uuid,

--- a/app/domain/services/record_responses/service.rb
+++ b/app/domain/services/record_responses/service.rb
@@ -8,9 +8,6 @@ class Services::RecordResponses::Service < Services::ApplicationService
         type: :record_response,
         course_uuid: response.fetch(:course_uuid),
         sequence_number: response.fetch(:sequence_number),
-        sequence_number_association_extra_attributes: {
-            initial_ecosystem_uuid: response.fetch(:ecosystem_uuid),
-        },
         data: response.slice(
           :response_uuid,
           :course_uuid,

--- a/app/domain/services/update_course_active_dates/service.rb
+++ b/app/domain/services/update_course_active_dates/service.rb
@@ -1,13 +1,10 @@
 class Services::UpdateCourseActiveDates::Service < Services::ApplicationService
-  def process(request_uuid:, course_uuid:, ecosystem_uuid:, sequence_number:, starts_at:, ends_at:, updated_at:)
+  def process(request_uuid:, course_uuid:, sequence_number:, starts_at:, ends_at:, updated_at:)
     CourseEvent.append(
       uuid: request_uuid,
       type: :update_course_active_dates,
       course_uuid: course_uuid,
       sequence_number: sequence_number,
-      sequence_number_association_extra_attributes: {
-        initial_ecosystem_uuid: ecosystem_uuid,
-      },
       data: {
         request_uuid: request_uuid,
         course_uuid: course_uuid,

--- a/app/domain/services/update_course_ecosystem/service.rb
+++ b/app/domain/services/update_course_ecosystem/service.rb
@@ -22,9 +22,6 @@ class Services::UpdateCourseEcosystem::Service < Services::ApplicationService
             type: :update_course_ecosystem,
             course_uuid: request.fetch(:course_uuid),
             sequence_number: request.fetch(:sequence_number),
-            sequence_number_association_extra_attributes: {
-              initial_ecosystem_uuid: request.fetch(:course_ecosystem_uuid),
-            },
             data: request.slice(
               :request_uuid,
               :course_uuid,

--- a/app/domain/services/update_course_exercise_exclusions/service.rb
+++ b/app/domain/services/update_course_exercise_exclusions/service.rb
@@ -1,13 +1,10 @@
 class Services::UpdateCourseExerciseExclusions::Service < Services::ApplicationService
-  def process(request_uuid:, course_uuid:, ecosystem_uuid:, sequence_number:, exclusions:, updated_at:)
+  def process(request_uuid:, course_uuid:, sequence_number:, exclusions:, updated_at:)
     CourseEvent.append(
       uuid:            request_uuid,
       type:            :update_course_excluded_exercises,
       course_uuid:     course_uuid,
       sequence_number: sequence_number,
-      sequence_number_association_extra_attributes: {
-        initial_ecosystem_uuid: ecosystem_uuid,
-      },
       data:            {
         request_uuid: request_uuid,
         course_uuid:     course_uuid,

--- a/app/domain/services/update_global_exercise_exclusions/service.rb
+++ b/app/domain/services/update_global_exercise_exclusions/service.rb
@@ -1,13 +1,10 @@
 class Services::UpdateGlobalExerciseExclusions::Service < Services::ApplicationService
-  def process(request_uuid:, course_uuid:, sequence_number:, ecosystem_uuid:, exclusions:, updated_at:)
+  def process(request_uuid:, course_uuid:, sequence_number:, exclusions:, updated_at:)
     CourseEvent.append(
       uuid:            request_uuid,
       type:            :update_globally_excluded_exercises,
       course_uuid:     course_uuid,
       sequence_number: sequence_number,
-      sequence_number_association_extra_attributes: {
-        initial_ecosystem_uuid: ecosystem_uuid,
-      },
       data:            {
         request_uuid: request_uuid,
         course_uuid:     course_uuid,

--- a/app/domain/services/update_rosters/service.rb
+++ b/app/domain/services/update_rosters/service.rb
@@ -11,16 +11,13 @@ class Services::UpdateRosters::Service < Services::ApplicationService
       roster.fetch(:students).each do |student|
         student_attributes << { uuid: student.fetch(:student_uuid) }
       end
-      course = Course.find_by(uuid: roster.fetch(:course_uuid))
+
       course_event_attributes << {
         # No appropriate uuid in the request to use here
-        uuid: course.uuid,
+        uuid: roster.fetch(:request_uuid),
         type: :update_roster,
         course_uuid: roster.fetch(:course_uuid),
         sequence_number: roster.fetch(:sequence_number),
-        sequence_number_association_extra_attributes: {
-            initial_ecosystem_uuid: course.initial_ecosystem_uuid,
-        },
         data: roster.slice(
           :request_uuid,
           :course_uuid,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,7 +6,6 @@ class Course < ApplicationRecord
                            foreign_key: :course_uuid,
                            inverse_of: :course
 
-  validates :initial_ecosystem_uuid, presence: true
   validates :sequence_number,
             presence: true,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }

--- a/db/migrate/20190114195540_non_null_course_ecosystem.rb
+++ b/db/migrate/20190114195540_non_null_course_ecosystem.rb
@@ -1,5 +1,0 @@
-class NonNullCourseEcosystem < ActiveRecord::Migration[5.0]
-  def change
-    change_column_null :courses, :initial_ecosystem_uuid, false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190114195540) do
+ActiveRecord::Schema.define(version: 20181112182803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,7 +104,7 @@ ActiveRecord::Schema.define(version: 20190114195540) do
     t.uuid     "uuid",                                                                               null: false
     t.integer  "metadata_sequence_number", default: -> { "next_course_metadata_sequence_number()" }, null: false
     t.integer  "sequence_number",                                                                    null: false
-    t.uuid     "initial_ecosystem_uuid",                                                             null: false
+    t.uuid     "initial_ecosystem_uuid"
     t.datetime "created_at",                                                                         null: false
     t.datetime "updated_at",                                                                         null: false
     t.index ["metadata_sequence_number"], name: "index_courses_on_metadata_sequence_number", unique: true, using: :btree

--- a/spec/controllers/courses_controller/controller_spec.rb
+++ b/spec/controllers/courses_controller/controller_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe CoursesController, type: :request do
   context '#update_course_active_dates' do
     let(:given_request_uuid)    { SecureRandom.uuid }
     let(:given_course_uuid)     { SecureRandom.uuid }
-    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) }
     let(:given_starts_at)       { Time.current.yesterday.iso8601(6) }
     let(:given_ends_at)         { Time.current.tomorrow.iso8601(6) }
@@ -65,7 +64,6 @@ RSpec.describe CoursesController, type: :request do
       {
         request_uuid: given_request_uuid,
         course_uuid: given_course_uuid,
-        ecosystem_uuid: given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         starts_at: given_starts_at,
         ends_at: given_ends_at,

--- a/spec/controllers/exercise_exclusions_controller/controller_spec.rb
+++ b/spec/controllers/exercise_exclusions_controller/controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ExerciseExclusionsController, type: :request do
   context '#update_course_excluded_exercises' do
     let(:given_course_uuid)     { SecureRandom.uuid }
     let(:given_request_uuid)    { SecureRandom.uuid }
-    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) }
     let(:number_of_exclusions)  { 10 }
 
@@ -26,7 +25,6 @@ RSpec.describe ExerciseExclusionsController, type: :request do
       {
         request_uuid:    given_request_uuid,
         course_uuid:     given_course_uuid,
-        ecosystem_uuid:  given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         exclusions:      given_exclusions,
         updated_at:      given_updated_at
@@ -81,7 +79,6 @@ RSpec.describe ExerciseExclusionsController, type: :request do
   context '#update_globally_excluded_exercises' do
     let(:given_request_uuid)    { SecureRandom.uuid }
     let(:given_course_uuid)     { SecureRandom.uuid }
-    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) }
     let(:number_of_exclusions)  { 10 }
 
@@ -103,7 +100,6 @@ RSpec.describe ExerciseExclusionsController, type: :request do
       {
         request_uuid:    given_request_uuid,
         course_uuid:     given_course_uuid,
-        ecosystem_uuid:  given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         exclusions:      given_exclusions,
         updated_at:      given_updated_at

--- a/spec/domain/services/fetch_course_metadatas/service_spec.rb
+++ b/spec/domain/services/fetch_course_metadatas/service_spec.rb
@@ -19,15 +19,17 @@ RSpec.describe Services::FetchCourseMetadatas::Service, type: :service do
   end
 
   context "when there are courses" do
-    let(:courses_count)                         { rand(10) + 1        }
-    let(:given_metadata_sequence_number_offset) { rand(courses_count) }
+    let(:courses_count)                         { rand(10) + 2            }
+    let(:given_metadata_sequence_number_offset) { rand(courses_count - 1) }
 
     let!(:courses)                              do
-      FactoryGirl.create_list(:course, courses_count)
+      FactoryGirl.create_list(:course, courses_count).tap do |courses|
+        courses.last.update_attribute :initial_ecosystem_uuid, nil
+      end
     end
 
     let(:expected_responses) do
-      courses.select do |course|
+      courses[0..-2].select do |course|
         course.metadata_sequence_number >= given_metadata_sequence_number_offset
       end.map do |course|
         {

--- a/spec/domain/services/update_course_active_dates/service_spec.rb
+++ b/spec/domain/services/update_course_active_dates/service_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Services::UpdateCourseActiveDates::Service, type: :service do
 
   let(:given_request_uuid)    { SecureRandom.uuid }
   let(:given_course_uuid)     { SecureRandom.uuid }
-  let(:given_ecosystem_uuid)  { SecureRandom.uuid }
   let(:given_sequence_number) { rand(10) }
   let(:given_starts_at)       { Time.current.yesterday.iso8601(6) }
   let(:given_ends_at)         { Time.current.tomorrow.iso8601(6)  }
@@ -15,7 +14,6 @@ RSpec.describe Services::UpdateCourseActiveDates::Service, type: :service do
     service.process(
       request_uuid: given_request_uuid,
       course_uuid: given_course_uuid,
-      ecosystem_uuid: given_ecosystem_uuid,
       sequence_number: given_sequence_number,
       starts_at: given_starts_at,
       ends_at: given_ends_at,

--- a/spec/domain/services/update_course_ecosystem/service_spec.rb
+++ b/spec/domain/services/update_course_ecosystem/service_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe Services::UpdateCourseEcosystem::Service, type: :service do
   let(:given_sequence_number)  { rand(1000) }
   let(:given_preparation_uuid) { SecureRandom.uuid }
   let(:given_updated_at)       { Time.current.iso8601(6) }
-  let(:given_course_ecosystem_uuid) { SecureRandom.uuid }
 
   let(:given_update_requests)  do
     [
       {
         request_uuid: given_request_uuid,
         course_uuid: given_course_uuid,
-        course_ecosystem_uuid: given_course_ecosystem_uuid,
         sequence_number: given_sequence_number,
         preparation_uuid: given_preparation_uuid,
         updated_at: given_updated_at

--- a/spec/domain/services/update_rosters/service_spec.rb
+++ b/spec/domain/services/update_rosters/service_spec.rb
@@ -90,10 +90,10 @@ RSpec.describe Services::UpdateRosters::Service, type: :service do
   let(:action)                                         { service.process(rosters: given_rosters) }
 
   context "when a previously-existing course_uuid and sequence_number combination is given" do
-      before(:each) do
-        FactoryGirl.create :course_event,
-                           course_uuid: given_course_uuid,
-                           sequence_number: given_sequence_number
+    before(:each) do
+      FactoryGirl.create :course_event,
+                         course_uuid: given_course_uuid,
+                         sequence_number: given_sequence_number
     end
 
     it "a CourseEvent is NOT created and an error is returned" do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     uuid                   { SecureRandom.uuid }
     sequence_number        0
     initial_ecosystem_uuid { SecureRandom.uuid }
+
     after(:create) { |course| course.reload }
   end
 end

--- a/spec/models/concerns/append_only_with_unique_uuid_spec.rb
+++ b/spec/models/concerns/append_only_with_unique_uuid_spec.rb
@@ -4,20 +4,6 @@ RSpec.describe AppendOnlyWithUniqueUuid, type: :concern do
   let(:test_class)    { CourseEvent }
 
   let(:test_instance) { FactoryGirl.build(:course_event) }
-  let(:event_1_attributes) {
-      FactoryGirl.build(:course_event).attributes.merge(
-          sequence_number_association_extra_attributes: {
-              initial_ecosystem_uuid: SecureRandom.uuid,
-          }
-      )
-  }
-  let(:event_2_attributes) {
-      FactoryGirl.build(:course_event).attributes.merge(
-          sequence_number_association_extra_attributes: {
-              initial_ecosystem_uuid: SecureRandom.uuid,
-          }
-      )
-  }
 
   it 'makes instances of the including class append-only' do
     expect(test_instance.new_record?).to eq true
@@ -32,6 +18,12 @@ RSpec.describe AppendOnlyWithUniqueUuid, type: :concern do
   end
 
   it 'can import multiple records through append' do
+    event_1_attributes = FactoryGirl.build(:course_event).attributes.merge(
+      sequence_number_association_extra_attributes: {
+        initial_ecosystem_uuid: SecureRandom.uuid,
+      }
+    )
+    event_2_attributes = FactoryGirl.build(:course_event).attributes
     attributes_array = [ event_1_attributes, event_2_attributes ]
     expect{test_class.append attributes_array}.to change{test_class.count}.by(2)
     expect{test_class.append attributes_array}.not_to change{test_class.count}
@@ -47,47 +39,39 @@ RSpec.describe AppendOnlyWithUniqueUuid, type: :concern do
 
   it 'creates the associated record or updates its sequence_number' do
     course_uuid = SecureRandom.uuid
+    ecosystem_uuid = SecureRandom.uuid
     event_1_attributes = FactoryGirl.build(
       :course_event, course: nil, course_uuid: course_uuid, sequence_number: 0
     ).attributes.merge(
-          sequence_number_association_extra_attributes: {
-              initial_ecosystem_uuid: SecureRandom.uuid,
-          }
-      )
+      sequence_number_association_extra_attributes: {
+        initial_ecosystem_uuid: ecosystem_uuid,
+      }
+    )
     expect{ test_class.append [ event_1_attributes ] }.to change { Course.count }.by(1)
     course = Course.find_by! uuid: course_uuid
     expect(course.sequence_number).to eq 1
+    expect(course.initial_ecosystem_uuid).to eq ecosystem_uuid
 
     event_2_attributes = FactoryGirl.build(
       :course_event, course: course, sequence_number: 1
-    ).attributes.merge(
-          sequence_number_association_extra_attributes: {
-              initial_ecosystem_uuid: SecureRandom.uuid,
-          }
-      )
+    ).attributes
     event_3_attributes = FactoryGirl.build(
       :course_event, course: course, sequence_number: 3
-    ).attributes.merge(
-          sequence_number_association_extra_attributes: {
-              initial_ecosystem_uuid: SecureRandom.uuid,
-          }
-      )
+    ).attributes
     attributes_array = [ event_2_attributes, event_3_attributes ]
 
     expect{ test_class.append attributes_array }.to(
       change { course.reload.sequence_number }.from(1).to(4)
     )
+    expect(course.initial_ecosystem_uuid).to eq ecosystem_uuid
 
     event_4_attributes = FactoryGirl.build(
       :course_event, course: course, sequence_number: 2
-    ).attributes.merge(
-          sequence_number_association_extra_attributes: {
-              initial_ecosystem_uuid: SecureRandom.uuid,
-          }
-      )
+    ).attributes
 
     expect{ test_class.append [ event_4_attributes ] }.not_to(
       change { course.reload.sequence_number }
     )
+    expect(course.initial_ecosystem_uuid).to eq ecosystem_uuid
   end
 end

--- a/spec/support/exercise_exclusions_services_shared_examples.rb
+++ b/spec/support/exercise_exclusions_services_shared_examples.rb
@@ -7,7 +7,6 @@ module ExerciseExclusionsServicesSharedExamples
 
     let(:given_request_uuid)    { SecureRandom.uuid }
     let(:given_course_uuid)     { SecureRandom.uuid }
-    let(:given_ecosystem_uuid)  { SecureRandom.uuid }
     let(:given_sequence_number) { rand(10) + 1 }
     let(:given_exclusions)      { generate_exclusions(number_of_exclusions) }
     let(:given_updated_at)      { Time.current.iso8601(6) }
@@ -16,7 +15,6 @@ module ExerciseExclusionsServicesSharedExamples
       service.process(
         request_uuid: given_request_uuid,
         course_uuid: given_course_uuid,
-        ecosystem_uuid: given_ecosystem_uuid,
         sequence_number: given_sequence_number,
         exclusions: given_exclusions,
         updated_at: given_updated_at
@@ -123,16 +121,12 @@ module ExerciseExclusionsServicesSharedExamples
 
   def save_preexisting_exclusions(type, course_uuid, generated_exclusions)
     request_uuid = SecureRandom.uuid
-    ecosystem_uuid = SecureRandom.uuid
 
     CourseEvent.append(
       uuid: request_uuid,
       type: type,
       course_uuid: course_uuid,
       sequence_number: 0,
-      sequence_number_association_extra_attributes: {
-        initial_ecosystem_uuid: ecosystem_uuid,
-      },
       data: {
         request_uuid: request_uuid,
         exclusions: generated_exclusions


### PR DESCRIPTION
This PR reverts making the initial_ecosystem_uuid non-null because events may arrive out of order. A `create_course` event will set the `initial_ecosystem_uuid` when it arrives. The issues we had before were caused by the code that does this only being deployed several days after https://github.com/openstax/biglearn-api/blob/master/db/migrate/20181112182803_create_courses.rb had ran, due to an incomplete rollback.

This PR also prevents courses with no initial_ecosystem_uuid from being sent to biglearn-scheduler as metadata.